### PR TITLE
Fix port creation on shared networks

### DIFF
--- a/networking_arista/ml2/mechanism_arista.py
+++ b/networking_arista/ml2/mechanism_arista.py
@@ -211,7 +211,13 @@ class AristaDriver(driver_api.MechanismDriver):
             if not tenant_id:
                 tenant_id = context._plugin_context.tenant_id
             with self.eos_sync_lock:
-                if not db_lib.is_network_provisioned(tenant_id, network_id):
+                # If network does not exist under this tenant,
+                # it may be a shared network. Get shared network owner Id
+                net_provisioned = (
+                    db_lib.is_network_provisioned(tenant_id, network_id) or
+                    self.ndb.get_shared_network_owner_id(network_id)
+                )
+                if not net_provisioned:
                     # Ignore this request if network is not provisioned
                     return
                 db_lib.remember_tenant(tenant_id)


### PR DESCRIPTION
In create_port_precommit, the VM was only added to the Arista DB if the
port was associated to a network in the same tenant. But in the case of
a shared network, the port tenant and the network tenant can be
different, while the VM should still be added to the DB.

This commit ensures the VM is added to the DB when connected to a shared
network, using the same logic as in create_port_postcommit.